### PR TITLE
Update website and docs for train_number/line_number schema

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,8 @@ The monthly processed dataset contains the following key columns:
 ### Identification
 - `station_name` - Name of the station
 - `eva` - EVA station number (unique identifier)
-- `train_name` - Name of the train (e.g., "ICE 123", "RE 5")
+- `train_number` - Train number / Zugnummer, the raw `tl.n` value identifying a specific train run (e.g., "123", "12603"). Combine with `train_type` for a label like "ICE 123"
+- `line_number` - Line number / Liniennummer, the raw `ar.l`/`dp.l` value identifying the route, non-unique (e.g., "RB23", "14"); null for long-distance trains (ICE/IC/EC)
 - `train_type` - Type of train. There are 65 unique train types in the dataset. Most common types include:
   - `S` - S-Bahn (urban trains)
   - `RE` - Regional Express

--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ The raw data contains the API responses in the following structure:
 | `month` | integer | Month of the request (partition key) |
 | `day` | integer | Day of the request (partition key) |
 
+### Schema Changelog
+
+- **2026-05**: The `train_name` column was split into two raw columns: `train_number` (the Zugnummer / `tl.n`, identifying a specific train run) and `line_number` (the Liniennummer / `ar.l`/`dp.l`, identifying the route; null for long-distance trains). To get the old `train_name` label (e.g. `"ICE 123"`), combine `train_type` and `train_number`. All historical monthly files were reprocessed with the new schema.
+
 ## Developing Setup
 
 Install uv and git and run the following commands to download the code and setup everything.

--- a/notebooks/zugverbindung.ipynb
+++ b/notebooks/zugverbindung.ipynb
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "cell-1",
    "metadata": {
     "execution": {
@@ -33,32 +33,12 @@
      "shell.execute_reply": "2026-05-03T12:13:06.417969Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Loaded 29,166,117 records from 2 files\n",
-      "Files: ['data-2026-03.parquet', 'data-2026-04.parquet']\n"
-     ]
-    }
-   ],
-   "source": [
-    "data_dir = Path(\"../monthly_processed_data\")\n",
-    "files = sorted(data_dir.glob(\"data-*.parquet\"))[-2:]\n",
-    "\n",
-    "df_list = []\n",
-    "for file in files:\n",
-    "    df_list.append(pd.read_parquet(file, columns=[\"delay_in_min\", \"train_name\", \"train_type\", \"is_canceled\"]))\n",
-    "df = pd.concat(df_list, ignore_index=True)\n",
-    "\n",
-    "print(f\"Loaded {len(df):,} records from {len(files)} files\")\n",
-    "print(f\"Files: {[f.name for f in files]}\")"
-   ]
+   "outputs": [],
+   "source": "data_dir = Path(\"../monthly_processed_data\")\nfiles = sorted(data_dir.glob(\"data-*.parquet\"))[-2:]\n\ndf_list = []\nfor file in files:\n    df_list.append(pd.read_parquet(file, columns=[\"delay_in_min\", \"train_number\", \"train_type\", \"is_canceled\"]))\ndf = pd.concat(df_list, ignore_index=True)\n\nprint(f\"Loaded {len(df):,} records from {len(files)} files\")\nprint(f\"Files: {[f.name for f in files]}\")"
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "cell-2",
    "metadata": {
     "execution": {
@@ -68,44 +48,8 @@
      "shell.execute_reply": "2026-05-03T12:13:07.402974Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Found 875 long-distance trains with at least 100 journeys\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Define long-distance train types\n",
-    "long_distance_train_types = [\"ICE\", \"IC\", \"FLX\", \"EC\"]\n",
-    "\n",
-    "# Calculate average delays, cancellation percentages, and sample counts by train\n",
-    "train_stats = (\n",
-    "    df[df[\"train_type\"].isin(long_distance_train_types)]\n",
-    "    .groupby(\"train_name\")\n",
-    "    .agg({\"delay_in_min\": [\"mean\", \"count\"], \"is_canceled\": \"mean\"})\n",
-    "    .sort_values((\"delay_in_min\", \"count\"), ascending=False)\n",
-    ")\n",
-    "\n",
-    "# Flatten column names and rename for clarity\n",
-    "train_stats.columns = [\"Durchschnittliche Versp\\u00e4tung [min]\", \"Anzahl Fahrten\", \"Ausfallquote [%]\"]\n",
-    "train_stats = train_stats.reset_index()\n",
-    "train_stats = train_stats.rename(columns={\"train_name\": \"Zugname\"})\n",
-    "\n",
-    "# Convert cancellation rate to percentage\n",
-    "train_stats[\"Ausfallquote [%]\"] = (train_stats[\"Ausfallquote [%]\"] * 100).round(2)\n",
-    "train_stats[\"Durchschnittliche Versp\\u00e4tung [min]\"] = train_stats[\"Durchschnittliche Versp\\u00e4tung [min]\"].round(2)\n",
-    "\n",
-    "# Filter to trains with at least 100 planned journeys\n",
-    "train_stats = train_stats[train_stats[\"Anzahl Fahrten\"] >= 100]\n",
-    "\n",
-    "# Reorder columns\n",
-    "train_stats = train_stats[[\"Zugname\", \"Durchschnittliche Versp\\u00e4tung [min]\", \"Ausfallquote [%]\", \"Anzahl Fahrten\"]]\n",
-    "\n",
-    "print(f\"Found {len(train_stats)} long-distance trains with at least 100 journeys\")"
-   ]
+   "outputs": [],
+   "source": "# Define long-distance train types\nlong_distance_train_types = [\"ICE\", \"IC\", \"FLX\", \"EC\"]\n\n# Build a display name (e.g. \"ICE 123\") from the train type and the Zugnummer (train_number)\ndf_long_distance = df[df[\"train_type\"].isin(long_distance_train_types)].copy()\ndf_long_distance[\"train_name\"] = df_long_distance[\"train_type\"] + \" \" + df_long_distance[\"train_number\"]\n\n# Calculate average delays, cancellation percentages, and sample counts by train\ntrain_stats = (\n    df_long_distance.groupby(\"train_name\")\n    .agg({\"delay_in_min\": [\"mean\", \"count\"], \"is_canceled\": \"mean\"})\n    .sort_values((\"delay_in_min\", \"count\"), ascending=False)\n)\n\n# Flatten column names and rename for clarity\ntrain_stats.columns = [\"Durchschnittliche Verspätung [min]\", \"Anzahl Fahrten\", \"Ausfallquote [%]\"]\ntrain_stats = train_stats.reset_index()\ntrain_stats = train_stats.rename(columns={\"train_name\": \"Zugname\"})\n\n# Convert cancellation rate to percentage\ntrain_stats[\"Ausfallquote [%]\"] = (train_stats[\"Ausfallquote [%]\"] * 100).round(2)\ntrain_stats[\"Durchschnittliche Verspätung [min]\"] = train_stats[\"Durchschnittliche Verspätung [min]\"].round(2)\n\n# Filter to trains with at least 100 planned journeys\ntrain_stats = train_stats[train_stats[\"Anzahl Fahrten\"] >= 100]\n\n# Reorder columns\ntrain_stats = train_stats[[\"Zugname\", \"Durchschnittliche Verspätung [min]\", \"Ausfallquote [%]\", \"Anzahl Fahrten\"]]\n\nprint(f\"Found {len(train_stats)} long-distance trains with at least 100 journeys\")"
   },
   {
    "cell_type": "code",

--- a/scripts/html_templates/duckdb_wasm_llm_hints.md
+++ b/scripts/html_templates/duckdb_wasm_llm_hints.md
@@ -18,7 +18,8 @@ Wichtige Spalten:
 Identifikation:
 - station_name: Name der Station
 - eva: EVA-Stationsnummer (eindeutiger Bezeichner)
-- train_name: Name des Zuges (z.B. "ICE 123", "RE 5")
+- train_number: Zugnummer (roher tl.n-Wert, identifiziert eine konkrete Zugfahrt, z.B. "123", "12603"); mit train_type kombinieren für eine Bezeichnung wie "ICE 123"
+- line_number: Liniennummer (roher ar.l/dp.l-Wert, identifiziert die Linie, nicht eindeutig, z.B. "RB23", "14"); null bei Fernverkehrszügen (ICE/IC/EC)
 - train_type: Zugtyp (z.B. "ICE", "IC", "RE", "RB", "S", "Bus")
   - S: S-Bahn (Nahverkehrszüge)
   - RE: Regional-Express


### PR DESCRIPTION
Follow-up to #12, which split `train_name` into `train_number` (raw Zugnummer `tl.n`) and `line_number` (raw Liniennummer `ar.l`/`dp.l`). This updates the consumers of the old column.

## Changes

- **`notebooks/zugverbindung.ipynb`**: loads `train_number` instead of `train_name` and builds the `"ICE 123"` display label from `train_type + train_number`. The rendered table output is unchanged, so the deployed page looks identical — the notebook just works against the new schema again. (HTML will regenerate via the normal pipeline once the reprocessed data is published.)
- **`scripts/html_templates/duckdb_wasm_llm_hints.md`**: documents `train_number` and `line_number` for the interactive query page's LLM hints.
- **`AGENTS.md`**: same schema update for the dev docs.
- **`README.md`**: adds a short "Schema Changelog" note recording the `train_name` split.

## Notes

The committed `stats/*.html` are untouched (the `zugverbindung` output is byte-identical, and the interactive query page isn't tracked). Regenerating with the new data is a no-op visually.